### PR TITLE
test: mock slack component in service test

### DIFF
--- a/test/service.test.js
+++ b/test/service.test.js
@@ -1,10 +1,12 @@
 const expect = require('expect.js');
 const supertest = require('supertest');
 const system = require('../system');
+const initSlack = require('./mocks/slackSystem');
 
 describe('Service Tests', () => {
   let request;
   const sys = system();
+  sys.set('slack', initSlack()).dependsOn();
 
   before(async () => {
     const { app } = await sys.start();


### PR DESCRIPTION
### Type:
* ~cicd: helm, docker & cicd adjustments.~
* ~feature: new capabilities.~
* fix: bug, hotfix, etc.
* ~refactor: enhacements.~
* ~style: changes in styles.~
* other: docs, tests.

### What's the focus of this PR:
Currently one of the tests (`service.test.js`) is ending up in error due to a missing environment variable:

```
1) Service Tests
       "before all" hook for "returns manifest":
     Error: Incoming webhook URL is required
```

This variable is used to initialize the `slack` component. In order to solve the problem, the test have been modified to inject a mock for the `slack` component into the system that we want to test. 

### Task list:

:heavy_check_mark: **Tests**
- [x] Replace `slack` component by mock in `service.test.js`. 
